### PR TITLE
Tag Entity 생성 후 Post Foreign Key로 연결한다.

### DIFF
--- a/src/controller/PostController.ts
+++ b/src/controller/PostController.ts
@@ -4,9 +4,10 @@ import { User } from '../entity/User';
 import { JwtRequest } from '../interface/interfaces';
 import { Response, Request } from 'express';
 
+
 export class PostController {
   static createPost = async (req: JwtRequest, res: Response) => {
-    const { title, content } = req.body;
+    const { title, content, tags } = req.body;
     const { id: userId } = req.decoded;
 
     const user = await myDataBase.getRepository(User).findOne({
@@ -17,6 +18,7 @@ export class PostController {
     post.title = title;
     post.content = content;
     post.author = user;
+    post.tags = tags;
 
     const result = await myDataBase.getRepository(Post).insert(post);
     res.status(201).send(result);

--- a/src/entity/Post.ts
+++ b/src/entity/Post.ts
@@ -1,14 +1,28 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+
+} from 'typeorm';
 import { User } from './User';
 
+
+
 @Entity()
-export class Post {
+export class Post extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   postId: string;
   @Column()
   title: string;
   @Column()
   content: string;
+  @Column("simple-array", { nullable: true })
+  tags: string[];
   @ManyToOne(() => User, (user) => user.postList)
   author: User;
   @CreateDateColumn()


### PR DESCRIPTION
### 변경 사항
- 🚀 기능 추가: 태그를 string 배열로 저장할 수 있도록 `tags` 필드 추가
- 🔧 코드 수정: 태그 검색 기능 구현에 필요한 코드 추가 및 수정
- 🗑️ 코드 삭제: 이전에 사용하지 않았던 필드 및 함수 삭제

### 관련 이슈
- 🔍 이 PR은 이슈 #22 와 관련이 있습니다.

### 스크린샷
- 없음

### 추가 사항
- ℹ️ 이전에는 관계형 데이터베이스의 Many-to-Many 관계를 사용하려고 
   했지만, 중간 테이블을 관리하는 것이 번거로워서 `tags` 필드에 `simple-array` 타입을 
사용하여 구현하였습니다.

### 체크리스트
- [x] ✅ 변경 사항을 로컬에서 테스트했습니다.
- [x] 📝 새로 추가하거나 수정한 코드에 적절한 문서를 추가했습니다.
- [x] 🧪 코드가 프로젝트의 기존 코드 표준을 충족시키는지 확인했습니다.
- [x] ✔️ 기존의 테스트 스위트를 실행하여 모든 테스트가 여전히 통과되는지 확인했습니다.
- [x] 👀 이 PR에 리뷰어를 할당했습니다.
